### PR TITLE
Add root view for routing to single check providers

### DIFF
--- a/status/check_providers.py
+++ b/status/check_providers.py
@@ -41,7 +41,7 @@ def celery(workers, *args, **kwargs):
         ping_response = celery_inspect.ping() or {}
         active_workers = ping_response.keys()
         workers_status = {w: w in active_workers for w in workers}
-    except AttributeError:
+    except (AttributeError, OSError):
         workers_status = None
 
     return workers_status

--- a/status/urls.py
+++ b/status/urls.py
@@ -4,7 +4,7 @@ URLs.
 """
 from django.conf.urls import patterns, url
 
-from status.views import ProviderAPIView
+from status.views import ProviderAPIView, RootAPIView
 from status import settings
 
 urlpatterns = patterns('')
@@ -15,3 +15,5 @@ providers = [url(r'^api/{}/?$'.format(a),
              for a, p, args, kwargs in settings.CHECK_PROVIDERS]
 
 urlpatterns += providers
+
+urlpatterns += [url(r'^api/?$', RootAPIView.as_view())]

--- a/status/views/api.py
+++ b/status/views/api.py
@@ -3,12 +3,15 @@
 Views for status API.
 """
 import importlib
+
+from django.core.urlresolvers import reverse
 from django.http import JsonResponse
-from django.utils.decorators import classonlymethod
 from django.views.generic import View
 from django.views.generic.base import ContextMixin
 
-__all__ = ['ProviderAPIView']
+from status import settings
+
+__all__ = ['ProviderAPIView', 'RootAPIView']
 
 
 class JSONResponseMixin(object):
@@ -55,6 +58,19 @@ class APIView(JSONView, ContextMixin):
 
     def delete(self, request, *args, **kwargs):
         return self.get(request, *args, **kwargs)
+
+
+class RootAPIView(APIView):
+    """
+    Root API view that routes to each single ProviderAPIView
+    """
+    def __init__(self):
+        self.providers = settings.CHECK_PROVIDERS
+        super(RootAPIView, self).__init__()
+
+    def get(self, request, *args, **kwargs):
+        context = {name: request.build_absolute_uri(reverse("api_{}".format(name))) for name, _, _, _ in self.providers}
+        return self.render_to_response(context)
 
 
 class ProviderAPIView(APIView):


### PR DESCRIPTION
This adds a router-like view on "^api/" with simple urls to check providers. 
It looks like: 
{
**celery**: "http://localhost:8000/status/api/celery",
**code**: "http://localhost:8000/status/api/code",
**celery/stats**: "http://localhost:8000/status/api/celery/stats",
**databases/stats**: "http://localhost:8000/status/api/databases/stats",
**ping**: "http://localhost:8000/status/api/ping",
**databases**: "http://localhost:8000/status/api/databases",
**caches**: "http://localhost:8000/status/api/caches"
}
