### PR TITLE
Remove the api prefix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,31 +45,31 @@ By default **Django status** provides the follow checks:
 
 Ping
     A ping to application.
-    URL: /api/ping
+    URL: /ping
 
 Code
     Source code stats such as current active branch, last commit, if debug is active...
-    URL: /api/code
+    URL: /code
 
 Databases
     Check if databases are running.
-    URL: /api/databases
+    URL: /databases
 
 Databases stats
     Show stats for all databases.
-    URL: /api/databases/stats
+    URL: /databases/stats
 
 Caches
     Check if caches are running.
-    URL: /api/caches
+    URL: /caches
 
 Celery
     Check if celery workers defined in settings are running.
-    URL: /api/celery
+    URL: /celery
 
 Celery stats
     Show celery worker stats.
-    URL: /api/celery/stats
+    URL: /celery/stats
 
 Settings
 ========
@@ -98,4 +98,3 @@ List of hostname from celery workers to be checked.
 Default::
 
     STATUS_CELERY_WORKERS = ()
-

--- a/status/urls.py
+++ b/status/urls.py
@@ -9,11 +9,12 @@ from status import settings
 
 urlpatterns = patterns('')
 
-providers = [url(r'^api/{}/?$'.format(a),
+app_name = 'status'
+providers = [url(r'^{}/?$'.format(a),
                  ProviderAPIView.as_view(provider=p, provider_args=args, provider_kwargs=kwargs),
-                 name='api_{}'.format(a))
+                 name=a)
              for a, p, args, kwargs in settings.CHECK_PROVIDERS]
 
 urlpatterns += providers
 
-urlpatterns += [url(r'^api/?$', RootAPIView.as_view())]
+urlpatterns += [url(r'^$', RootAPIView.as_view())]

--- a/status/views/api.py
+++ b/status/views/api.py
@@ -69,7 +69,7 @@ class RootAPIView(APIView):
         super(RootAPIView, self).__init__()
 
     def get(self, request, *args, **kwargs):
-        context = {name: request.build_absolute_uri(reverse("api_{}".format(name))) for name, _, _, _ in self.providers}
+        context = {name: request.build_absolute_uri(reverse("status:%s" % name)) for name, _, _, _ in self.providers}
         return self.render_to_response(context)
 
 


### PR DESCRIPTION
Using a namespace instead.
The api prefix should be added in the outer project urls if wanted :
url(r'^status/prefix/', include('status.urls')),
