### PR TITLE
Changed url-patterns for supporting django>1.8

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 Contributors
 ============
  * Ebury
+ * Miguel Barrientos (`@mbarrientos <https://github.com/mbarrientos/>`_)

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Django Status
 =============
 
-:Version: 1.2.0
+:Version: 1.2.1
 :Status: Production/Stable
 :Author: José Antonio Perdiguero López
 

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -1,18 +1,18 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
 
     # Status urls
     url(r'^status/', include('status.urls'))
-)
+]
 
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/status/__init__.py
+++ b/status/__init__.py
@@ -2,7 +2,7 @@
 """
 Django Status application.
 """
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 __license__ = 'GPLv3'
 
 __author__ = 'José Antonio Perdiguero López'

--- a/status/urls.py
+++ b/status/urls.py
@@ -2,18 +2,16 @@
 """
 URLs.
 """
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-from status.views import ProviderAPIView, RootAPIView
 from status import settings
-
-urlpatterns = patterns('')
+from status.views import ProviderAPIView, RootAPIView
 
 providers = [url(r'^api/{}/?$'.format(a),
                  ProviderAPIView.as_view(provider=p, provider_args=args, provider_kwargs=kwargs),
                  name='api_{}'.format(a))
              for a, p, args, kwargs in settings.CHECK_PROVIDERS]
 
-urlpatterns += providers
+urlpatterns = providers
 
 urlpatterns += [url(r'^api/?$', RootAPIView.as_view())]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -38,11 +38,11 @@ USE_L10N = True
 
 USE_TZ = True
 
-MEDIA_ROOT = PROJECT_PATH + '/media/'
+MEDIA_ROOT = BASE_DIR + '/media/'
 
 MEDIA_URL = '/media/'
 
-STATIC_ROOT = PROJECT_PATH + '/static/'
+STATIC_ROOT = BASE_DIR + '/static/'
 
 STATIC_URL = '/static/'
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist = py34-django18
 [testenv]
 deps =
     django18: Django==1.8
+    -r{toxinidir}/requirements_base.txt
     -r{toxinidir}/requirements_test.txt
-    -r{toxinidir}/requirements.txt
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = tests.settings


### PR DESCRIPTION
Using "patterns" at urls.py was breaking support with Django versions higher than 1.8.

Also, some minor fixes on tox and settings.
