### PR TITLE
Updating to new location as of Django 1.10

### DIFF
--- a/status/api/mixins.py
+++ b/status/api/mixins.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class ProviderMixin:


### PR DESCRIPTION
As of Django 1.10, reverse() is no longer located at django.core.urlresolvers, and has been moved to django.urls. The old import no longer works in Django >2.0.